### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "name": "Object tags editor",
     "description": "Edit tags of each object on image",
     "docker_image": "supervisely/base-py-sdk:6.73.564",
-    "min_instance_version": "6.9.22",
+    "instance_version": "6.15.60",
     "icon": "https://user-images.githubusercontent.com/115161827/211073191-4a8d5728-6f12-48b7-aa39-ac3fd8cb3f61.jpg",
     "icon_cover": true,
     "poster": "https://user-images.githubusercontent.com/115161827/211074304-491b8e19-1639-406f-9949-b0ed68da0186.png",

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
     "version": "2.0.0",
     "name": "Object tags editor",
     "description": "Edit tags of each object on image",
-    "docker_image": "supervisely/base-py-sdk:6.73.116",
+    "docker_image": "supervisely/base-py-sdk:6.73.564",
     "min_instance_version": "6.9.22",
     "icon": "https://user-images.githubusercontent.com/115161827/211073191-4a8d5728-6f12-48b7-aa39-ac3fd8cb3f61.jpg",
     "icon_cover": true,

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,3 @@
-supervisely==6.73.116
+supervisely==6.73.564
 # code formatter
 black


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
